### PR TITLE
Remove index.css imports from event sites

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,9 +18,6 @@ server.get("/lecturesathome",(req,res) => {
 server.get("/insideMicrosoft",(req,res) => {
 	res.sendFile(getStaticFile("insideMicrosoft.html"));
 });
-server.get("/mlhlocalhackday",(req,res) => {
-	res.sendFile(getStaticFile("mlhLocalHackDay.html"));
-});
 server.get("/eventcal",(req,res) => {
 	res.sendFile(getStaticFile("eventcal.html"));
 });

--- a/static/index.css
+++ b/static/index.css
@@ -28,7 +28,6 @@
     --color-text-primary: #000000;
     /*color-text-secondary is used on the text elements that are not as important as other text and thus should not be the focus.*/
     --color-text-secondary: #3B3A39;
-    --color-yellow: rgb(255, 212, 0);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -45,7 +44,6 @@
         --color-secondary-transparent: rgba(37, 36, 35, 0.8);
         --color-text-primary: #f3f2f1;
         --color-text-secondary: #C8C6C4;
-        --color-yellow: #F3E0BE;
     }
 }
 

--- a/static/lecturesathome.html
+++ b/static/lecturesathome.html
@@ -7,7 +7,6 @@
 	<link rel="shortcut icon" href="https://mccwebfiles.blob.core.windows.net/$web/favicon.ico" type="image/x-icon">
 	<link rel="icon" href="https://mccwebfiles.blob.core.windows.net/$web/favicon.ico" type="image/x-icon">
 	<link rel="stylesheet" type="text/css" href="styles.css" />
-	<link rel="stylesheet" type="text/css" href="index.css" />
 	<title>Lectures@Home</title>
 	<script>
 		/**

--- a/static/mlhLocalHackDay.html
+++ b/static/mlhLocalHackDay.html
@@ -7,7 +7,6 @@
 		<link rel="shortcut icon" href="https://mccwebfiles.blob.core.windows.net/$web/favicon.ico" type="image/x-icon">
 		<link rel="icon" href="https://mccwebfiles.blob.core.windows.net/$web/favicon.ico" type="image/x-icon">
         <link rel="stylesheet" type="text/css" href="styles.css" />
-        <link rel="stylesheet" type="text/css" href="index.css"/>
 		<title>Local Hack Day - share</title>
 		<script>
 			/**


### PR DESCRIPTION
Because text was not legible I stopped using index.css in the lectures@home and mlh local hack day event pages. In addition I removed the route to the mlh local hack day page.