### PR TITLE
Add numbers to hexagons in join section

### DIFF
--- a/static/Assets/SVG/hexagon_1.svg
+++ b/static/Assets/SVG/hexagon_1.svg
@@ -1,0 +1,1 @@
+<svg id="Ebene_1" data-name="Ebene 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 243 269"><defs><style>.cls-1{fill:none;stroke:#fff;stroke-width:6px;}.cls-2{font-size:132px;fill:#fff;font-family:Calibri;}</style></defs><path class="cls-1" d="M28.8,79.33l92.7-52.88,92.7,52.88V185l-92.7,52.88L28.8,185Z"/><text class="cls-2" transform="translate(88.05 169.71)">1</text></svg>

--- a/static/Assets/SVG/hexagon_2.svg
+++ b/static/Assets/SVG/hexagon_2.svg
@@ -1,0 +1,1 @@
+<svg id="Ebene_1" data-name="Ebene 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 243 269"><defs><style>.cls-1{fill:none;stroke:#fff;stroke-width:6px;}.cls-2{font-size:132px;fill:#fff;font-family:Calibri;}</style></defs><path class="cls-1" d="M28.8,79.33l92.7-52.88,92.7,52.88V185l-92.7,52.88L28.8,185Z"/><text class="cls-2" transform="translate(88.05 169.71)">2</text></svg>

--- a/static/Assets/SVG/hexagon_3.svg
+++ b/static/Assets/SVG/hexagon_3.svg
@@ -1,0 +1,1 @@
+<svg id="Ebene_1" data-name="Ebene 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 243 269"><defs><style>.cls-1{fill:none;stroke:#fff;stroke-width:6px;}.cls-2{font-size:132px;fill:#fff;font-family:Calibri;}</style></defs><path class="cls-1" d="M28.8,79.33l92.7-52.88,92.7,52.88V185l-92.7,52.88L28.8,185Z"/><text class="cls-2" transform="translate(88.05 169.71)">3</text></svg>

--- a/static/Styles/index.css
+++ b/static/Styles/index.css
@@ -163,6 +163,21 @@ p {
     width: 180px;
     display: block;
     margin: 0 auto;
+
+
+    position: relative; top: 0; left: 0; grid-row: 1/2; grid-column: 1/2;
+}
+
+.joinHexaNumber{
+    position: relative; top: 0; grid-row: 1/2; grid-column: 1/2; margin: 0; padding: 0;
+   
+}
+
+.joinHexaContainer{
+    width: 180px;
+    display: block;
+    margin: 0 auto;
+    display:grid; grid-template-rows: 1fr; grid-template-columns:1fr; align-items: center; justify-items :center;
 }
 
 #endLogo {

--- a/static/index.html
+++ b/static/index.html
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
     <head>
         <meta  charset="utf-8">
         <meta name="viewport" content="width=device-width">
@@ -126,7 +126,7 @@
                         <div id="contact">
 
                             <!-- Zahlen in die Hexagone -->
-                            <img class="joinHexa" src="Assets/SVG/hexagon_blank.svg" alt="Contact">
+                            <img class="joinHexa" src="Assets/SVG/hexagon_1.svg" alt="Contact">
                             <div class="motivationText showOnScroll">
                                 <h1>Contact</h1>
                                 <p>Do you want to become a member? Just contact us, we'd like to hear from you!</p>
@@ -137,7 +137,7 @@
                             <span><big>&#129066;</big></span>
                         </div>
                         <div id="interview">
-                            <img class="joinHexa" src="Assets/SVG/hexagon_blank.svg" alt="Interview">
+                            <img class="joinHexa" src="Assets/SVG/hexagon_2.svg" alt="Interview">
                             <div class="motivationText showOnScroll">
                                 <h1>Interview</h1>
                                 <p>Tell us about yourself! What's your passion? What motivates you, and how can we help you to achieve your goals?</p>
@@ -147,7 +147,7 @@
                             <span><big>&#129066;</big></span>
                         </div>
                         <div id="engage">
-                            <img class="joinHexa" src="Assets/SVG/hexagon_blank.svg" alt="Engage">
+                            <img class="joinHexa" src="Assets/SVG/hexagon_3.svg" alt="Engage">
                             <div class="motivationText showOnScroll">
                                 <h1>Engage</h1>
                                 <p>Enjoy being a member, engage and hop on to our events and projects.</p>

--- a/static/index.html
+++ b/static/index.html
@@ -123,10 +123,19 @@
                 <div class="sectionDiv">
                     <h1>How to Join</h1>
                     <div id="joinElements">
+                       
+                        
+                        
                         <div id="contact">
-
+                            
                             <!-- Zahlen in die Hexagone -->
-                            <img class="joinHexa" src="Assets/SVG/hexagon_1.svg" alt="Contact">
+                            <span class="joinHexaContainer">
+                                <img class="joinHexa" src="Assets/SVG/hexagon_blank.svg" alt="Contact">
+                                <h1 class="joinHexaNumber">
+                                    1
+                                </h1>
+                               
+                             </span>
                             <div class="motivationText showOnScroll">
                                 <h1>Contact</h1>
                                 <p>Do you want to become a member? Just contact us, we'd like to hear from you!</p>
@@ -137,7 +146,13 @@
                             <span><big>&#129066;</big></span>
                         </div>
                         <div id="interview">
-                            <img class="joinHexa" src="Assets/SVG/hexagon_2.svg" alt="Interview">
+                            <span class="joinHexaContainer">
+                                <img class="joinHexa" src="Assets/SVG/hexagon_blank.svg" alt="Interview">
+                                <h1 class="joinHexaNumber">
+                                    2
+                                </h1>
+                               
+                             </span>
                             <div class="motivationText showOnScroll">
                                 <h1>Interview</h1>
                                 <p>Tell us about yourself! What's your passion? What motivates you, and how can we help you to achieve your goals?</p>
@@ -147,7 +162,13 @@
                             <span><big>&#129066;</big></span>
                         </div>
                         <div id="engage">
-                            <img class="joinHexa" src="Assets/SVG/hexagon_3.svg" alt="Engage">
+                            <span class="joinHexaContainer">
+                                <img class="joinHexa" src="Assets/SVG/hexagon_blank.svg" alt="Engage">
+                                <h1 class="joinHexaNumber">
+                                    3
+                                </h1>
+                               
+                             </span>
                             <div class="motivationText showOnScroll">
                                 <h1>Engage</h1>
                                 <p>Enjoy being a member, engage and hop on to our events and projects.</p>


### PR DESCRIPTION
This pull request closes #30 . However, the solution is, just as the other hexagons on the website, not easily configurable. This is reflected in another issue (see #43), which asks for a approach which is applicable to all hexagon elements which we use.

Also, since #30 is a design issue, I would like the requested reviewers to comment on the proposed solution. Of course, you might as well reject the pull request if you dislike the added numbers (in comparison to the previous design).