### PR TITLE
Thinner Arrows for "How to Join"

### DIFF
--- a/static/Assets/SVG/thin_arrow.svg
+++ b/static/Assets/SVG/thin_arrow.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 243 269" style="enable-background:new 0 0 243 269;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#FFFFFF;stroke-width:6;}
+	.st1{fill:#FFFFFF;stroke:#FFFFFF;stroke-width:6;}
+</style>
+<line class="st0" x1="45.8" y1="134.5" x2="197.2" y2="134.5"/>
+<polygon class="st1" points="190.6,134.5 190.6,126.8 197.2,130.7 203.9,134.5 197.2,138.3 190.6,142.2 "/>
+</svg>

--- a/static/Styles/index.css
+++ b/static/Styles/index.css
@@ -320,8 +320,7 @@ p {
     }
 
     .arrow {
-        display: inline;
-        font-size: 120px;
+        display: block;
     }
 
     #endSection div:nth-child(1) {

--- a/static/index.html
+++ b/static/index.html
@@ -137,14 +137,14 @@
                             <img class="joinHexa" src="Assets/SVG/thin_arrow.svg" alt="Interview"> 
                         </div>
                         <div id="interview">
-                            <img class="joinHexa" src="Assets/SVG/hexagon_blank.svg" alt="Interview">
+                            <img class="joinHexa" src="Assets/SVG/hexagon_blank.svg" alt="Arrow">
                             <div class="motivationText showOnScroll">
                                 <h1>Interview</h1>
                                 <p>Tell us about yourself! What's your passion? What motivates you, and how can we help you to achieve your goals?</p>
                             </div>    
                         </div>
                         <div class="arrow">
-                            <img class="joinHexa" src="Assets/SVG/thin_arrow.svg" alt="Interview"> 
+                            <img class="joinHexa" src="Assets/SVG/thin_arrow.svg" alt="Arrow"> 
                         </div>
                         <div id="engage">
                             <img class="joinHexa" src="Assets/SVG/hexagon_blank.svg" alt="Engage">

--- a/static/index.html
+++ b/static/index.html
@@ -134,7 +134,7 @@
                         </div>
                         <!-- Dünnere Pfeile -->
                         <div class="arrow">
-                            <span><big>&#129066;</big></span>
+                            <img class="joinHexa" src="Assets/SVG/thin_arrow.svg" alt="Interview"> 
                         </div>
                         <div id="interview">
                             <img class="joinHexa" src="Assets/SVG/hexagon_blank.svg" alt="Interview">
@@ -144,7 +144,7 @@
                             </div>    
                         </div>
                         <div class="arrow">
-                            <span><big>&#129066;</big></span>
+                            <img class="joinHexa" src="Assets/SVG/thin_arrow.svg" alt="Interview"> 
                         </div>
                         <div id="engage">
                             <img class="joinHexa" src="Assets/SVG/hexagon_blank.svg" alt="Engage">

--- a/static/index.html
+++ b/static/index.html
@@ -134,10 +134,10 @@
                         </div>
                         <!-- Dünnere Pfeile -->
                         <div class="arrow">
-                            <img class="joinHexa" src="Assets/SVG/thin_arrow.svg" alt="Interview"> 
+                            <img class="joinHexa" src="Assets/SVG/thin_arrow.svg" alt="Arrow"> 
                         </div>
                         <div id="interview">
-                            <img class="joinHexa" src="Assets/SVG/hexagon_blank.svg" alt="Arrow">
+                            <img class="joinHexa" src="Assets/SVG/hexagon_blank.svg" alt="Interview">
                             <div class="motivationText showOnScroll">
                                 <h1>Interview</h1>
                                 <p>Tell us about yourself! What's your passion? What motivates you, and how can we help you to achieve your goals?</p>


### PR DESCRIPTION
This pull request closes #29. The previously used HTML arrows are replaced by thinner SVG arrows (same thickness as the surrounding hexagons).  Additionally, the used arrows slightly change the distance between hexagons, i.e. both hexagons and arrows have the same dimensions.

![grafik](https://user-images.githubusercontent.com/38311128/105059015-24cdb080-5a77-11eb-8f1e-2b3e59b48afc.png)

As the referred issue also notes, this is a design issue. Thus, I would appreciate your feedback on this matter.